### PR TITLE
Various fixes suggested by clippy

### DIFF
--- a/src/bit_string/mod.rs
+++ b/src/bit_string/mod.rs
@@ -17,7 +17,7 @@ impl BitString {
         let bits_to_ignore = 64 - n;
         let remaining_bits = self.b << bits_to_ignore;
 
-        remaining_bits.count_ones() as u64
+        u64::from(remaining_bits.count_ones())
     }
 }
 

--- a/tests/lehmer_test.rs
+++ b/tests/lehmer_test.rs
@@ -4,31 +4,31 @@ use lehmer::Lehmer;
 
 #[test]
 fn it_can_convert_between_permutations_lehmer_codes_and_decimals() {
-    assert_example(vec![0, 1], vec![0, 0], 0);
-    assert_example(vec![1, 0], vec![1, 0], 1);
+    assert_example(&[0, 1], &[0, 0], 0);
+    assert_example(&[1, 0], &[1, 0], 1);
 
-    assert_example(vec![0, 1, 2, 3, 4], vec![0, 0, 0, 0, 0], 0);
-    assert_example(vec![0, 1, 2, 4, 3], vec![0, 0, 0, 1, 0], 1);
-    assert_example(vec![1, 0, 4, 3, 2], vec![1, 0, 2, 1, 0], 29);
-    assert_example(vec![3, 4, 1, 2, 0], vec![3, 3, 1, 1, 0], 93);
-    assert_example(vec![4, 3, 2, 1, 0], vec![4, 3, 2, 1, 0], 119);
+    assert_example(&[0, 1, 2, 3, 4], &[0, 0, 0, 0, 0], 0);
+    assert_example(&[0, 1, 2, 4, 3], &[0, 0, 0, 1, 0], 1);
+    assert_example(&[1, 0, 4, 3, 2], &[1, 0, 2, 1, 0], 29);
+    assert_example(&[3, 4, 1, 2, 0], &[3, 3, 1, 1, 0], 93);
+    assert_example(&[4, 3, 2, 1, 0], &[4, 3, 2, 1, 0], 119);
 
-    assert_example(vec![0, 1, 2, 3, 4, 5, 6], vec![0, 0, 0, 0, 0, 0, 0], 0);
-    assert_example(vec![2, 1, 5, 4, 6, 0, 3], vec![2, 1, 3, 2, 2, 0, 0], 1648);
-    assert_example(vec![5, 0, 1, 3, 6, 2, 4], vec![5, 0, 0, 1, 2, 0, 0], 3610);
-    assert_example(vec![4, 2, 6, 1, 0, 5, 3], vec![4, 2, 4, 1, 0, 1, 0], 3223);
-    assert_example(vec![6, 5, 4, 3, 2, 1, 0], vec![6, 5, 4, 3, 2, 1, 0], 5039);
+    assert_example(&[0, 1, 2, 3, 4, 5, 6], &[0, 0, 0, 0, 0, 0, 0], 0);
+    assert_example(&[2, 1, 5, 4, 6, 0, 3], &[2, 1, 3, 2, 2, 0, 0], 1648);
+    assert_example(&[5, 0, 1, 3, 6, 2, 4], &[5, 0, 0, 1, 2, 0, 0], 3610);
+    assert_example(&[4, 2, 6, 1, 0, 5, 3], &[4, 2, 4, 1, 0, 1, 0], 3223);
+    assert_example(&[6, 5, 4, 3, 2, 1, 0], &[6, 5, 4, 3, 2, 1, 0], 5039);
 
     assert_example(
-        vec![7, 12, 14, 4, 3, 20, 5, 9, 6, 11, 0, 18, 10, 16, 1, 2, 8, 17, 15, 19, 13],
-        vec![7, 11, 12, 4, 3, 15, 3, 5, 3, 5, 0, 8, 3, 5, 0, 0, 0, 2, 1, 1, 0],
+        &[7, 12, 14, 4, 3, 20, 5, 9, 6, 11, 0, 18, 10, 16, 1, 2, 8, 17, 15, 19, 13],
+        &[7, 11, 12, 4, 3, 15, 3, 5, 3, 5, 0, 8, 3, 5, 0, 0, 0, 2, 1, 1, 0],
         <u64>::max_value(),
     );
 }
 
-fn assert_example(permutation: Vec<u64>, code: Vec<u64>, decimal: u64) {
+fn assert_example(permutation: &[u64], code: &[u64], decimal: u64) {
     let mut lehmer: Lehmer;
-    let clone = permutation.clone();
+    let clone = permutation.to_owned();
 
     lehmer = Lehmer::from_permutation(clone);
     assert_eq!(lehmer.code, code);


### PR DESCRIPTION
Running https://github.com/rust-lang-nursery/rust-clippy against the crate revealed a potentially silent lossy cast from u32 to u64.

There's more detail in the commit messages but see the following:

* https://rust-lang-nursery.github.io/rust-clippy/v0.0.187/index.html#needless_pass_by_value
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.187/index.html#cast_lossless